### PR TITLE
Revert RSASSA-PSS parameters

### DIFF
--- a/lib/plug_signature/crypto.ex
+++ b/lib/plug_signature/crypto.ex
@@ -44,11 +44,7 @@ defmodule PlugSignature.Crypto do
   """
   def verify!(payload, "hs2019", signature, rsa_public_key(publicExponent: e, modulus: n)) do
     # Use PSS padding; requires workaround for https://bugs.erlang.org/browse/ERL-878
-    :crypto.verify(:rsa, :sha512, payload, signature, [e, n],
-      rsa_padding: :rsa_pkcs1_pss_padding,
-      rsa_pss_saltlen: 94,
-      rsa_mgf1_md: :sha256
-    )
+    :crypto.verify(:rsa, :sha512, payload, signature, [e, n], rsa_padding: :rsa_pkcs1_pss_padding)
   end
 
   def verify!(payload, "hs2019", signature, {_point, _ecpk_parameters} = public_key) do
@@ -114,11 +110,7 @@ defmodule PlugSignature.Crypto do
   """
   def sign!(payload, "hs2019", rsa_private_key(publicExponent: e, modulus: n, privateExponent: d)) do
     # Use PSS padding; requires workaround for https://bugs.erlang.org/browse/ERL-878
-    :crypto.sign(:rsa, :sha512, payload, [e, n, d],
-      rsa_padding: :rsa_pkcs1_pss_padding,
-      rsa_pss_saltlen: 94,
-      rsa_mgf1_md: :sha256
-    )
+    :crypto.sign(:rsa, :sha512, payload, [e, n, d], rsa_padding: :rsa_pkcs1_pss_padding)
   end
 
   def sign!(payload, "hs2019", ec_private_key() = private_key) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PlugSignature.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.7.0"
 
   def project do
     [


### PR DESCRIPTION
Reverts aabcdbbd49e841e31544f3f5a5744be3216eb2cb. I believe the parameters used in the HTTP signatures compliance test suite are actually incorrect, and the draft itself does not specify any special values.

There is no reason to believe the authors of the spec intended to use a non-default hash function, especially since this would go against best practices mentioned in RFC8017 (referenced from the spec) and would hurt interoperability, as not all libraries allow the user to modify the PSS defaults.

Hopefully any ambiguity will be cleared up as the new draft-ietf-httpbis-message-signatures (see #1) matures.