### PR TITLE
Address removal of :crypto.hmac/3 in Erlang/OTP 24

### DIFF
--- a/lib/plug_signature/crypto.ex
+++ b/lib/plug_signature/crypto.ex
@@ -54,7 +54,7 @@ defmodule PlugSignature.Crypto do
   end
 
   def verify!(payload, "hs2019", signature, hmac_secret) when is_binary(hmac_secret) do
-    signature == :crypto.hmac(:sha512, hmac_secret, payload)
+    signature == hmac_fun(:sha512, hmac_secret, payload)
   end
 
   def verify!(payload, "rsa-sha256", signature, rsa_public_key() = public_key) do
@@ -74,7 +74,7 @@ defmodule PlugSignature.Crypto do
   end
 
   def verify!(payload, "hmac-sha256", signature, hmac_secret) when is_binary(hmac_secret) do
-    signature == :crypto.hmac(:sha256, hmac_secret, payload)
+    signature == hmac_fun(:sha256, hmac_secret, payload)
   end
 
   def verify(payload, algorithm, signature, public_key) do
@@ -118,7 +118,7 @@ defmodule PlugSignature.Crypto do
   end
 
   def sign!(payload, "hs2019", hmac_secret) when is_binary(hmac_secret) do
-    :crypto.hmac(:sha512, hmac_secret, payload)
+    hmac_fun(:sha512, hmac_secret, payload)
   end
 
   def sign!(payload, "rsa-sha256", rsa_private_key() = private_key) do
@@ -136,7 +136,7 @@ defmodule PlugSignature.Crypto do
   end
 
   def sign!(payload, "hmac-sha256", hmac_secret) when is_binary(hmac_secret) do
-    :crypto.hmac(:sha256, hmac_secret, payload)
+    hmac_fun(:sha256, hmac_secret, payload)
   end
 
   @doc """
@@ -148,5 +148,12 @@ defmodule PlugSignature.Crypto do
     {:ok, sign!(payload, algorithm, private_key)}
   rescue
     _ -> {:error, "bad algorithm or key"}
+  end
+
+  # TODO: remove when we require OTP 22.1
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    defp hmac_fun(digest, key, payload), do: :crypto.mac(:hmac, digest, key, payload)
+  else
+    defp hmac_fun(digest, key, payload), do: :crypto.hmac(digest, key, payload)
   end
 end


### PR DESCRIPTION
Hey Bram,
`:crypto.hmac/3` [was dropped](https://www.erlang.org/doc/general_info/removed.html#functions-removed-in-otp-24) in Erlang/OPT 24. I took this workaround from [plug_crypto](https://github.com/elixir-plug/plug_crypto/blob/6ba8fd42a68351459fe6c769ca04aea6022a5cd1/lib/plug/crypto/key_generator.ex#L96) library and verified that the test suit passes on OTP 23 and 25.