### PR TITLE
Fix PlugSignature to work with Plug 1.14

### DIFF
--- a/lib/plug_signature/conn_test.ex
+++ b/lib/plug_signature/conn_test.ex
@@ -82,7 +82,6 @@ defmodule PlugSignature.ConnTest do
 
     conn =
       conn
-      |> maybe_add_host_header()
       |> put_req_header("date", date)
 
     request_target =
@@ -107,6 +106,7 @@ defmodule PlugSignature.ConnTest do
           "(created)" -> "(created): #{created}"
           "(expires)" -> "(expires): #{expires}"
           "date" -> "date: #{date}"
+          "host" -> "host: #{conn.host}"
           header -> "#{header}: #{get_req_header(conn, header) |> Enum.join(",")}"
         end)
       end)
@@ -221,18 +221,6 @@ defmodule PlugSignature.ConnTest do
     now = DateTime.utc_now() |> DateTime.to_unix()
     to_string(now + validity)
   end
-
-  defp maybe_add_host_header(%Plug.Conn{host: host} = conn) when is_binary(host) do
-    case get_req_header(conn, "host") do
-      [] ->
-        put_req_header(conn, "host", host)
-
-      _ ->
-        conn
-    end
-  end
-
-  defp maybe_add_host_header(conn), do: conn
 
   defp raise_on_missing_phoenix_conntest! do
     Code.ensure_loaded?(Phoenix.ConnTest) ||

--- a/lib/plug_signature/signature_string.ex
+++ b/lib/plug_signature/signature_string.ex
@@ -3,7 +3,9 @@ defmodule PlugSignature.SignatureString do
 
   def build(conn, signature_opts, algorithm, header_list) do
     signature_string =
-      Enum.map_join(header_list, "\n", &header_part(conn, signature_opts, algorithm, &1))
+      header_list
+      |> Enum.map(&String.downcase/1)
+      |> Enum.map_join("\n", &header_part(conn, signature_opts, algorithm, &1))
 
     {:ok, signature_string}
   rescue
@@ -30,10 +32,11 @@ defmodule PlugSignature.SignatureString do
     "(expires): #{Keyword.fetch!(signature_opts, :expires)}"
   end
 
-  defp header_part(conn, _signature_opts, _algorithm, header)
-       when header not in ["(created)", "(expires)"] do
-    header_name = String.downcase(header)
+  defp header_part(conn, _signature_opts, _algorithm, "host") do
+    "host: #{conn.host}"
+  end
 
+  defp header_part(conn, _signature_opts, _algorithm, header_name) do
     values =
       conn.req_headers
       |> Enum.filter(&match?({^header_name, _}, &1))

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule PlugSignature.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:plug, "~> 1.14"},
+      {:plug, "~> 1.5"},
       {:nimble_parsec, "~> 1.0"},
       {:ex_doc, "~> 0.21", only: :dev},
       {:credo, "~> 1.1", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule PlugSignature.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:plug, "~> 1.5"},
+      {:plug, "~> 1.14"},
       {:nimble_parsec, "~> 1.0"},
       {:ex_doc, "~> 0.21", only: :dev},
       {:credo, "~> 1.1", only: :dev},

--- a/test/plug_signature/signature_string_test.exs
+++ b/test/plug_signature/signature_string_test.exs
@@ -255,7 +255,14 @@ defmodule PlugSignature.SignatureStringTest do
         [path, query] -> {path, query}
       end
 
+    host =
+      case List.keyfind(headers, "host", 0) do
+        {"host", host} -> host
+        nil -> nil
+      end
+
     %Plug.Conn{
+      host: host || "www.example.com",
       method: method,
       request_path: request_path,
       query_string: query_string,

--- a/test/plug_signature_test.exs
+++ b/test/plug_signature_test.exs
@@ -206,7 +206,7 @@ defmodule PlugSignatureTest do
         conn =
           conn()
           |> with_signature(key, key_id, config)
-          |> put_req_header("host", "example.org")
+          |> Map.put(:host, "example.org")
           |> PlugSignature.call(PlugSignature.init(config))
 
         assert conn.halted


### PR DESCRIPTION
The problem is that since Plug 1.14.0, we shouldn't set the host header; instead, we need to set `Plug.Conn.host` directly. Otherwise, Plug spits `** (Plug.Conn.InvalidHeaderError)`.

The change is not backwards compatible, but so is the one in Plug.
